### PR TITLE
Fixed a little bug

### DIFF
--- a/src/org/selfkleptomaniac/ti/imageasresized/ImageasresizedModule.java
+++ b/src/org/selfkleptomaniac/ti/imageasresized/ImageasresizedModule.java
@@ -190,7 +190,7 @@ public class ImageasresizedModule extends KrollModule
   private int calcSampleSize(BitmapFactory.Options opts, int width, int height){
     int scaleW = Math.max(1, opts.outWidth / width);
     int scaleH = Math.max(1, opts.outHeight / height);
-    int sampleSize = Math.max(scaleW, scaleH);
+    int sampleSize = Math.min(scaleW, scaleH);
     return sampleSize;
   }
 }


### PR DESCRIPTION
If you use the max() scale, the sample image can be smaller than the requested image.
